### PR TITLE
Add support for MC 1.21.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
             12102 -> "0.106.1+1.21.2"
             12104 -> "0.111.0+1.21.4"
             12105 -> "0.119.9+1.21.5"
+            12106 -> "0.119.9+1.21.6"
             else -> throw UnsupportedOperationException()
         }
         val fabricApiModules = mutableListOf(
@@ -168,6 +169,7 @@ dependencies {
 
     if (platform.isFabric) {
         val modMenuVersion = when {
+            mcVersion >= 12106 -> "14.0.0-rc.2"
             mcVersion >= 12105 -> "14.0.0-rc.2"
             mcVersion >= 12104 -> "13.0.0-beta.1"
             mcVersion >= 12102 -> "12.0.0-beta.1"

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -204,6 +204,7 @@ defaultTasks("bundleJar")
 preprocess {
     strictExtraMappings.set(true)
 
+    val mc12106 = createNode("1.21.6", 12106, "yarn")
     val mc12105 = createNode("1.21.5", 12105, "yarn")
     val mc12104 = createNode("1.21.4", 12104, "yarn")
     val mc12102 = createNode("1.21.2", 12102, "yarn")
@@ -236,6 +237,7 @@ preprocess {
     val mc10800 = createNode("1.8", 10800, "srg")
     val mc10710 = createNode("1.7.10", 10710, "srg")
 
+    mc12106.link(mc12105, file("versions/mapping-fabric-1.21.6-1.21.5.txt"))
     mc12105.link(mc12104, file("versions/mapping-fabric-1.21.5-1.21.4.txt"))
     mc12104.link(mc12102)
     mc12102.link(mc12100)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ val jGuiVersions = listOf(
         "1.21.2",
         "1.21.4",
         "1.21.5",
+        "1.21.6",
 )
 val replayModVersions = listOf(
         // "1.7.10",
@@ -76,6 +77,7 @@ val replayModVersions = listOf(
         "1.21.2",
         "1.21.4",
         "1.21.5",
+        "1.21.6",
 )
 
 rootProject.buildFileName = "root.gradle.kts"

--- a/versions/mapping-fabric-1.21.6-1.21.5.txt
+++ b/versions/mapping-fabric-1.21.6-1.21.5.txt
@@ -1,0 +1,2 @@
+com.mojang.blaze3d.vertex.VertexFormat net.minecraft.client.render.VertexFormat
+com.mojang.blaze3d.vertex.VertexFormatElement net.minecraft.client.render.VertexFormatElement


### PR DESCRIPTION
## Summary
- add 1.21.6 version directory and mapping file
- update build scripts for 1.21.6
- include new version in multi-project settings

## Testing
- `./gradlew :1.21.6:build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68555a5064b483319c272cdf7296b2e7