### PR TITLE
Add MC 1.21.6 setup and update docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Build
+        run: ./gradlew --parallel
+
+      - name: Upload jars
+        uses: actions/upload-artifact@v4
+        with:
+          name: replaymod-jars
+          path: versions/*/build/libs/*.jar

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,29 @@
+name: Docker Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          outputs: type=local,dest=output
+
+      - name: Upload jars
+        uses: actions/upload-artifact@v4
+        with:
+          name: replaymod-jars-docker
+          path: output/versions/*/build/libs/*.jar

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 	path = src/main/resources/assets/replaymod/lang
 	url = https://github.com/ReplayMod/Translations
 [submodule "ReplayStudio"]
-	path = libs/ReplayStudio
-	url = ../ReplayStudio
+        path = libs/ReplayStudio
+        url = https://github.com/ReplayMod/ReplayStudio

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:17-jdk AS build
+WORKDIR /opt/ReplayMod
+COPY . .
+RUN ./gradlew --parallel
+
+FROM scratch AS export
+COPY --from=build /opt/ReplayMod/versions /versions

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ For compiling 1.7.10, you must run `./gradlew :jGui:1.7.10:setupDecompWorkspace 
 You can build the mod by running `./gradlew build` (or just `./gradlew bundleJar`). You can then find the final jar files in `versions/$MCVERSION/build/libs/`.
 You can also build single versions by running `./gradlew :1.8:build` (or just `./gradlew :1.8:bundleJar`) (builds the MC 1.8 version).
 
+### GitHub Actions
+This repository contains a workflow at `.github/workflows/build.yml`.
+Every push or pull request automatically compiles the mod and uploads
+the resulting jar files as workflow artifacts. Navigate to the "Build"
+workflow on GitHub and download the artifacts from a run to obtain the
+pre-built jars.
+
+### Docker
+You can also build the mod in a Docker container. Run
+`docker buildx build --output type=local,dest=output .` and find the
+compiled jars inside `output/versions/*/build/libs/`. The workflow
+`docker-build.yml` demonstrates building with Docker on GitHub.
+
 ### IntelliJ
 Ensure you have at least IDEA 2020.1.
 Build the mod via Gradle as explained above at least once (`./gradlew compileJava` should be sufficient). This will ensure that the sources for all MC versions are generated.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
             12102 -> "0.106.1+1.21.2"
             12104 -> "0.111.0+1.21.4"
             12105 -> "0.119.9+1.21.5"
+            12106 -> "0.119.9+1.21.6"
             else -> throw UnsupportedOperationException()
         }
         val fabricApiModules = mutableListOf(
@@ -168,6 +169,7 @@ dependencies {
 
     if (platform.isFabric) {
         val modMenuVersion = when {
+            mcVersion >= 12106 -> "14.0.0-rc.2"
             mcVersion >= 12105 -> "14.0.0-rc.2"
             mcVersion >= 12104 -> "13.0.0-beta.1"
             mcVersion >= 12102 -> "12.0.0-beta.1"

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -204,6 +204,7 @@ defaultTasks("bundleJar")
 preprocess {
     strictExtraMappings.set(true)
 
+    val mc12106 = createNode("1.21.6", 12106, "yarn")
     val mc12105 = createNode("1.21.5", 12105, "yarn")
     val mc12104 = createNode("1.21.4", 12104, "yarn")
     val mc12102 = createNode("1.21.2", 12102, "yarn")
@@ -236,6 +237,7 @@ preprocess {
     val mc10800 = createNode("1.8", 10800, "srg")
     val mc10710 = createNode("1.7.10", 10710, "srg")
 
+    mc12106.link(mc12105, file("versions/mapping-fabric-1.21.6-1.21.5.txt"))
     mc12105.link(mc12104, file("versions/mapping-fabric-1.21.5-1.21.4.txt"))
     mc12104.link(mc12102)
     mc12102.link(mc12100)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ val jGuiVersions = listOf(
         "1.21.2",
         "1.21.4",
         "1.21.5",
+        "1.21.6",
 )
 val replayModVersions = listOf(
         // "1.7.10",
@@ -76,6 +77,7 @@ val replayModVersions = listOf(
         "1.21.2",
         "1.21.4",
         "1.21.5",
+        "1.21.6",
 )
 
 rootProject.buildFileName = "root.gradle.kts"

--- a/versions/mapping-fabric-1.21.6-1.21.5.txt
+++ b/versions/mapping-fabric-1.21.6-1.21.5.txt
@@ -1,0 +1,2 @@
+com.mojang.blaze3d.vertex.VertexFormat net.minecraft.client.render.VertexFormat
+com.mojang.blaze3d.vertex.VertexFormatElement net.minecraft.client.render.VertexFormatElement


### PR DESCRIPTION
## Summary
- add GitHub Actions build workflow
- add configuration for MC 1.21.6
- fix ReplayStudio submodule URL
- document CI build in README
- add Dockerfile and workflow for Docker based builds

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68555a5064b483319c272cdf7296b2e7